### PR TITLE
docs(dotfiles): update CLAUDE.md and add README with recent changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Remote: `git@github.com:sacredyak/dotfiles.git`
 | `terminfo` | Terminal info entries |
 | `snippets` | Code/text snippets |
 
-Non-package items at root: `install/`, `CLAUDE.md`, `webp_convertor.sh`, `xterm-24bit.terminfo`, `clear-all`
+Non-package items at root: `CLAUDE.md`, `webp_convertor.sh`, `xterm-24bit.terminfo`, `clear-all`
 
 ## How to Apply Configs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,23 @@ Stow target is `$HOME` by default when running from the repo root. No `--target`
 - `hammerspoon/.hammerspoon/init.lua` — Hammerspoon automation entry point
 - `claude/.claude/settings.json` — Claude Code settings (hooks, permissions)
 - `claude/.claude/hooks/` — Claude Code hook scripts
+- `claude/.claude/hooks/auto-approve.sh` — env-var gated auto-approval hook (`CLAUDE_AUTO_APPROVE=1`)
 - `claude/.claude/skills/` — custom Claude Code skills
+- `claude/.claude/agents/neo.md` — neo orchestrator agent definition
+- `docs/obsidian-workflow.md` — Obsidian vault integration plan
+
+## Fish Claude Aliases
+
+Defined in `fish/.config/fish/config.fish`:
+
+| Alias | Model | Effort | Auto-approve |
+|-------|-------|--------|--------------|
+| `clb` | claude-sonnet-4-6 | medium | no |
+| `cld` | claude-opus (high) | high | no |
+| `clb-auto` | claude-sonnet-4-6 | medium | yes |
+| `cld-auto` | claude-opus (high) | high | yes |
+
+The `-auto` variants set `CLAUDE_AUTO_APPROVE=1`, which activates the `auto-approve.sh` PreToolUse hook to bypass most permission prompts. The hook maintains a denylist for destructive patterns and logs all auto-approved actions to `~/.claude/logs/auto-approve.jsonl`. You can also activate auto-approve on an existing session via the `cc-auto` Fish function.
 
 ## Conventions
 
@@ -89,4 +105,5 @@ Stow target is `$HOME` by default when running from the repo root. No `--target`
 | `neo` (agent) | Loaded via `agent: neo` in settings.json | Orchestrator — never does work directly, dispatches subagents for everything |
 | `capture-to-things` | Invoke explicitly when tasks/action items identified | Adds todos to Things 3 with correct project/area assignment |
 | `dotfiles` | Invoke when adding, editing, or restructuring dotfiles | Enforces stow conventions — never edit symlink targets, always dry-run before stowing |
+| `obsidian` | Invoke when creating `.md` files outside a git repo | Routes markdown to the correct Obsidian vault folder |
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+# dotfiles
+
+macOS dotfiles managed with [GNU Stow](https://www.gnu.org/software/stow/).
+
+## Prerequisites
+
+- [Homebrew](https://brew.sh/)
+- [GNU Stow](https://formulae.brew.sh/formula/stow) — `brew install stow`
+- [fish shell](https://fishshell.com/) — `brew install fish`
+
+## Quick Install
+
+```bash
+git clone git@github.com:sacredyak/dotfiles.git ~/.dotfiles
+cd ~/.dotfiles
+
+# Preview changes before applying (dry run)
+stow -n fish
+
+# Apply a package
+stow fish
+stow helix
+stow claude
+```
+
+Stow creates symlinks from each package into `$HOME`. The target is `$HOME` by default when run from the repo root — no `--target` flag needed.
+
+## Packages
+
+| Package | Manages |
+|---------|---------|
+| `fish` | Fish shell — `~/.config/fish/` (config, functions, completions, conf.d) |
+| `helix` | Helix editor — `~/.config/helix/` |
+| `hammerspoon` | Hammerspoon macOS automation — `~/.hammerspoon/` |
+| `git` | Git config — `~/.gitconfig` and related |
+| `nvim` | Neovim — `~/.config/nvim/` |
+| `tmux` | tmux config |
+| `yabai` | yabai tiling window manager config |
+| `skhd` | skhd hotkey daemon config |
+| `karabiner` | Karabiner-Elements key remapping — `~/.config/karabiner/` |
+| `ghostty` | Ghostty terminal config |
+| `kitty` | Kitty terminal config |
+| `wezterm` | WezTerm config |
+| `alacritty` | Alacritty terminal config |
+| `zellij` | Zellij terminal multiplexer config |
+| `lazygit` | lazygit config |
+| `gitui` | gitui config |
+| `tig` | tig config |
+| `bat` | bat (cat replacement) config |
+| `yazi` | yazi file manager config |
+| `ideavim` | IdeaVim (IntelliJ) — `~/.ideavimrc` |
+| `claude` | Claude Code — `~/.claude/` (settings, hooks, skills) |
+| `keylayout` | Custom keyboard layout files |
+| `terminfo` | Terminal info entries |
+| `snippets` | Code/text snippets |
+
+## Structure
+
+Each package mirrors the exact target path relative to `$HOME`. For example, a file at `~/.config/fish/config.fish` lives in the repo at `fish/.config/fish/config.fish`.
+
+To add a new tool: create a top-level directory with the correct mirrored path, then `stow <package>`.
+
+**Never edit files under `~/.config/` or `~/.hammerspoon/` directly** — those are symlinks. Always edit source files in `~/.dotfiles/<package>/`.
+
+## Docs
+
+See [`docs/`](docs/) for detailed workflow documentation.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ macOS dotfiles managed with [GNU Stow](https://www.gnu.org/software/stow/).
 
 ## Prerequisites
 
+- macOS
 - [Homebrew](https://brew.sh/)
 - [GNU Stow](https://formulae.brew.sh/formula/stow) — `brew install stow`
-- [fish shell](https://fishshell.com/) — `brew install fish`
+- git
 
 ## Quick Install
 
@@ -61,6 +62,10 @@ Each package mirrors the exact target path relative to `$HOME`. For example, a f
 To add a new tool: create a top-level directory with the correct mirrored path, then `stow <package>`.
 
 **Never edit files under `~/.config/` or `~/.hammerspoon/` directly** — those are symlinks. Always edit source files in `~/.dotfiles/<package>/`.
+
+## Utilities
+
+- **`clear-all`** — zsh script at repo root that unstows all packages at once (`stow -D` on each). Useful for a clean removal of all symlinks.
 
 ## Docs
 

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -22,3 +22,13 @@ See `@rules/context-mode.md` for context-mode routing rules and tool selection h
 See `@RTK.md` for RTK CLI usage and hook-based command rewriting.
 
 See `@rules/coding.md` for coding behavior principles.
+
+See `@rules/testing.md` for TDD workflow and test location rules.
+
+See `@rules/git.md` for commit format and PR standards.
+
+See `@rules/security.md` for security rules (no secrets, parameterized queries, etc.).
+
+See `@rules/skills.md` for active skills reference.
+
+See `@rules/file-creation.md` for markdown file routing rules.

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -22,13 +22,3 @@ See `@rules/context-mode.md` for context-mode routing rules and tool selection h
 See `@RTK.md` for RTK CLI usage and hook-based command rewriting.
 
 See `@rules/coding.md` for coding behavior principles.
-
-See `@rules/testing.md` for TDD workflow and test location rules.
-
-See `@rules/git.md` for commit format and PR standards.
-
-See `@rules/security.md` for security rules (no secrets, parameterized queries, etc.).
-
-See `@rules/skills.md` for active skills reference.
-
-See `@rules/file-creation.md` for markdown file routing rules.

--- a/git/.gitignore_global
+++ b/git/.gitignore_global
@@ -4,3 +4,4 @@ __backup__*
 .rgignore
 .git
 kls_database.db
+.serena/


### PR DESCRIPTION
## Changes

- **CLAUDE.md**: Added Key Files entries for `auto-approve.sh`, `neo.md`, `obsidian-workflow.md`; new Fish Claude Aliases section documenting `clb`/`cld`/`clb-auto`/`cld-auto`; added `obsidian` skill to Skills Reference
- **README.md**: Created public-facing README with prerequisites, quick install, packages table, and structure notes

Co-Authored-By: Claude Sonnet <noreply@anthropic.com>