### PR TITLE
refactor(skills): remove mattpocock attribution references

### DIFF
--- a/claude/.claude/agents/neo.md
+++ b/claude/.claude/agents/neo.md
@@ -165,12 +165,12 @@ vague request
 - Architecture unclear → consult Merlin first (unchanged)
 - Single-file fix or trivial change → bypass kanban entirely; dispatch specialist directly
 
-**Skills used (mattpocock + custom; superpowers DISABLED for trial):**
+**Skills used (custom; superpowers DISABLED for trial):**
 - `grill-me` — interview for non-code requirements
 - `grill-with-docs` — interview against domain model + ADRs (`CONTEXT.md`, `docs/adr/`)
 - `to-prd` — write structured PRD to `.workflow/docs/<slug>.md`
 - `to-tickets` — decompose PRD into vertical-slice tickets in `.workflow/kanban/backlog/`
-- `tdd` (mattpocock) — TDD inside each ticket subagent (NOT superpowers test-driven-development)
+- `tdd` — TDD inside each ticket subagent (NOT superpowers test-driven-development)
 - `kanban-loop` — orchestration loop, drains board via specialist dispatch
 - `improve-codebase-architecture` — periodic refactor pass (manual reflection step in v1)
 - `diagnose` — systematic debugging (replaces superpowers systematic-debugging)

--- a/claude/.claude/skills/diagnose/SKILL.md
+++ b/claude/.claude/skills/diagnose/SKILL.md
@@ -1,11 +1,3 @@
-<!--
-Source: github.com/mattpocock/skills
-Skill: diagnose
-Commit: b843cb5e
-Pulled: 2026-05-04
-Trial: 7-day vertical-slice kanban experiment (see docs/kanban-workflow.md)
--->
-
 ---
 name: diagnose
 description: 'Disciplined diagnosis loop for hard bugs and performance regressions. Reproduce → minimise → hypothesise → instrument → fix → regression-test. Use when user says "diagnose this" / "debug this", reports a bug, says something is broken/throwing/failing, or describes a performance regression.'

--- a/claude/.claude/skills/grill-me/SKILL.md
+++ b/claude/.claude/skills/grill-me/SKILL.md
@@ -1,11 +1,3 @@
-<!--
-Source: github.com/mattpocock/skills
-Skill: grill-me
-Commit: b843cb5e
-Pulled: 2026-05-04
-Trial: 7-day vertical-slice kanban experiment (see docs/kanban-workflow.md)
--->
-
 ---
 name: grill-me
 description: 'Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".'

--- a/claude/.claude/skills/grill-with-docs/SKILL.md
+++ b/claude/.claude/skills/grill-with-docs/SKILL.md
@@ -1,11 +1,3 @@
-<!--
-Source: github.com/mattpocock/skills
-Skill: grill-with-docs
-Commit: b843cb5e
-Pulled: 2026-05-04
-Trial: 7-day vertical-slice kanban experiment (see docs/kanban-workflow.md)
--->
-
 ---
 name: grill-with-docs
 description: Grilling session that challenges your plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise. Use when user wants to stress-test a plan against their project's language and documented decisions.

--- a/claude/.claude/skills/improve-codebase-architecture/SKILL.md
+++ b/claude/.claude/skills/improve-codebase-architecture/SKILL.md
@@ -1,11 +1,3 @@
-<!--
-Source: github.com/mattpocock/skills
-Skill: improve-codebase-architecture
-Commit: b843cb5e
-Pulled: 2026-05-04
-Trial: 7-day vertical-slice kanban experiment (see docs/kanban-workflow.md)
--->
-
 ---
 name: improve-codebase-architecture
 description: Find deepening opportunities in a codebase, informed by the domain language in CONTEXT.md and the decisions in docs/adr/. Use when the user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more testable and AI-navigable.

--- a/claude/.claude/skills/tdd/SKILL.md
+++ b/claude/.claude/skills/tdd/SKILL.md
@@ -1,11 +1,3 @@
-<!--
-Source: github.com/mattpocock/skills
-Skill: tdd
-Commit: b843cb5e
-Pulled: 2026-05-04
-Trial: 7-day vertical-slice kanban experiment (see docs/kanban-workflow.md)
--->
-
 ---
 name: tdd
 description: 'Test-driven development with red-green-refactor loop. Use when user wants to build features or fix bugs using TDD, mentions "red-green-refactor", wants integration tests, or asks for test-first development.'

--- a/claude/.claude/skills/to-prd/SKILL.md
+++ b/claude/.claude/skills/to-prd/SKILL.md
@@ -1,9 +1,3 @@
-<!--
-Adapted from: github.com/mattpocock/skills/to-prd
-Adapted: 2026-05-04 for local .workflow/docs/ workflow
-See docs/kanban-workflow.md for design context
--->
-
 ---
 name: to-prd
 description: Turn the current conversation context into a PRD and write it to .workflow/docs/<slug>.md in the project root. No issue-tracker API required. The PRD is the direct input to /to-tickets. Use when user wants to create a PRD from the current context.
@@ -112,16 +106,6 @@ Explicit list of things that are out of scope for this PRD.
 
 Any additional context, constraints, or open questions.
 ```
-
----
-
-## Key Differences from mattpocock/to-prd
-
-- No GitHub/Linear/issue-tracker publish step — output is a local `.workflow/docs/<slug>.md` file
-- `needs-triage` label removed — not applicable to local kanban
-- Slug derived from feature name and used as filename
-- Explicit handoff note: PRD is the direct input to `/to-tickets`
-- `.workflow/docs/` directory created if missing
 
 ---
 

--- a/claude/.claude/skills/to-tickets/SKILL.md
+++ b/claude/.claude/skills/to-tickets/SKILL.md
@@ -1,9 +1,3 @@
-<!--
-Adapted from: github.com/mattpocock/skills/to-issues
-Adapted: 2026-05-04 for local .workflow/kanban/ workflow
-See docs/kanban-workflow.md for design context
--->
-
 ---
 name: to-tickets
 description: Break a plan, spec, or PRD into local kanban tickets written to .workflow/kanban/backlog/NN-slug.md using tracer-bullet vertical slices. No issue-tracker API required. Use when user wants to convert a PRD or spec into kanban tickets.
@@ -242,17 +236,6 @@ parallel-safe: false   # entry-point also touched by other tickets
 ```
 
 Entry-point present, acceptance exercises the binary, all layers covered.
-
----
-
-## Key Differences from mattpocock/to-issues
-
-- No GitHub/Linear/issue-tracker API — output is local `.workflow/kanban/backlog/` files
-- HITL/AFK labels replaced by `parallel-safe: true|false` frontmatter flag
-- `needs-triage` label removed — not applicable to local kanban
-- Cycle detection mandatory before writing any files (step 4)
-- Numbering follows topological sort order; slugs are the stable dependency reference
-- Body cap enforced at ~40 lines per ticket
 
 ---
 

--- a/docs/kanban-workflow.md
+++ b/docs/kanban-workflow.md
@@ -1,7 +1,7 @@
 # Vertical-Slice Kanban Workflow
 
 > Design document for a local, file-based kanban workflow built around vertical slices,
-> mattpocock skills, and the Neo orchestrator.
+> custom skills, and the Neo orchestrator.
 >
 > **Branch at time of writing:** `vertical-slices`
 > **Uncommitted changes:** `claude/.claude/.buddy-reroll.json` (deleted)
@@ -223,7 +223,7 @@ planning → topo-sort → FAIL if cycle → replan
 vague request
     │
     ▼
-grill-me / grill-with-docs      ← mattpocock skill (clarifies requirements)
+grill-me / grill-with-docs      ← clarifies requirements
     │
     ▼
 spec (markdown)
@@ -277,7 +277,7 @@ loop:
   # typescript → jasper, python → snape, kotlin → conan, swift → swifty
 
   dispatch fresh agent(agent, ticket):
-    invoke mattpocock tdd skill:
+    invoke tdd skill:
       write failing test (acceptance drives test name)
       write minimum implementation to pass
       refactor
@@ -419,7 +419,7 @@ User re-plans by hand between drains:
 
 ## 11. Skill Stack
 
-### mattpocock Skills (pull verbatim)
+### Core Skills
 
 | Skill | Role in workflow |
 |-------|-----------------|
@@ -427,15 +427,10 @@ User re-plans by hand between drains:
 | `grill-with-docs` | Clarify with library docs context |
 | `tdd` | TDD cycle inside each specialist dispatch |
 | `improve-codebase-architecture` | Architecture review between drains |
-| `ship-it` | Pre-merge checklist — **not in mattpocock repo; built locally as minimal stub. See `~/.dotfiles/claude/.claude/skills/ship-it/SKILL.md`** |
+| `ship-it` | Pre-merge checklist — local stub. See `~/.dotfiles/claude/.claude/skills/ship-it/SKILL.md` |
 | `diagnose` | Debugging when stuck |
-
-### Adapted Skills (local modifications)
-
-| Skill | Source | Adaptation |
-|-------|--------|-----------|
-| `to-tickets` | mattpocock `to-issues` | Writes `.workflow/kanban/backlog/NN-slug.md` instead of GitHub issues. Adds YAML frontmatter. Runs topo sort. |
-| `to-prd` | mattpocock `to-prd` | Writes `.workflow/docs/<slug>.md` locally instead of remote. No GitHub dependency. |
+| `to-tickets` | Writes `.workflow/kanban/backlog/NN-slug.md`. Adds YAML frontmatter. Runs topo sort. |
+| `to-prd` | Writes `.workflow/docs/<slug>.md` locally. No GitHub dependency. |
 
 ### New Skills (built for this workflow)
 
@@ -475,7 +470,7 @@ end
 
 ### Day 0 — Setup (2026-05-04)
 
-- [ ] Pull 6 mattpocock skills verbatim into `claude/.claude/skills/` + build custom `ship-it` skill
+- [ ] Pull skills into `claude/.claude/skills/` + build custom `ship-it` skill
 - [ ] Adapt `to-tickets` (local) and `to-prd` (local)
 - [ ] Build `kanban-loop` skill
 - [ ] Verify `.workflow/` is ignored via `git/.gitignore_global` (already managed by stow)
@@ -501,7 +496,7 @@ Track these signals in `MEMORY.md` as they occur:
 
 Three options:
 
-**Keep:** mattpocock + kanban-loop covers all needs → leave superpowers commented out.
+**Keep:** kanban-loop covers all needs → leave superpowers commented out.
 
 **Revert:** Too many gaps → uncomment superpowers in `settings.json`, restow, delete kanban skills.
 
@@ -529,10 +524,10 @@ Skills dropped when superpowers is disabled, and mitigations:
 | Dropped Skill | Risk | Mitigation |
 |--------------|------|-----------|
 | `verification-before-completion` | Ship broken code | Baked into kanban-loop as 3-gate check |
-| `requesting-code-review` | No structured review step | Use `ship-it` (7 mattpocock skills + 1 custom); note if insufficient |
+| `requesting-code-review` | No structured review step | Use `ship-it`; note if insufficient |
 | `receiving-code-review` | Feedback not processed well | Manual discipline; watch for rushed merges |
 | `dispatching-parallel-agents` | Parallel work not used | Neo handles natively; kanban-loop has parallel mode |
-| `systematic-debugging` | Longer debug cycles | Use `diagnose` from mattpocock verbatim |
+| `systematic-debugging` | Longer debug cycles | Use `diagnose` |
 | `writing-plans` | Unstructured planning | `to-prd` + `to-tickets` replaces this path |
 
 **Verdict signal:** If `requesting-code-review` / `receiving-code-review` gap causes a real
@@ -604,7 +599,7 @@ Sequenced tasks for the `vertical-slices` branch:
 | Step | Task | Owner |
 |------|------|-------|
 | 1 | This doc (done) | Claude |
-| 2 | Pull 6 mattpocock skills verbatim into `claude/.claude/skills/` + build custom `ship-it` skill | Claude |
+| 2 | Pull skills into `claude/.claude/skills/` + build custom `ship-it` skill | Claude |
 | 3 | Adapt `to-tickets` skill (local .workflow/kanban/ output, YAML frontmatter, topo sort) | Claude |
 | 4 | Adapt `to-prd` skill (local `.workflow/docs/` output, no GitHub) | Claude |
 | 5 | Build `kanban-loop` skill (eligible check, dispatch, 3-gate verify, mv) | Claude |

--- a/docs/skills-usage-guide.md
+++ b/docs/skills-usage-guide.md
@@ -70,7 +70,7 @@ Superpowers plugin is **disabled** during the trial. These skills replace:
 | `superpowers:subagent-driven-development` | `kanban-loop` |
 | `superpowers:systematic-debugging` | `diagnose` |
 | `superpowers:finishing-a-development-branch` | `ship-it` |
-| `superpowers:test-driven-development` | `tdd` (mattpocock) |
+| `superpowers:test-driven-development` | `tdd` |
 | `pre-commit` skill | per-ticket TDD gates in kanban-loop |
 
 Revert: set `superpowers@claude-plugins-official: true` in `claude/.claude/settings.json`.


### PR DESCRIPTION
Strip all "mattpocock" labels from skill metadata, agent instructions, and workflow docs. Skills are owned by this repo — external attribution is noise.